### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn global add serverless
 ```
 Or via npm
 ```
-nom i -g serverless
+npm i -g serverless
 ```
 
 First clone the project: 


### PR DESCRIPTION
Existe um erro no comando `npm` no README.
Onde se lia `nom` foi corrigido para `npm`.